### PR TITLE
Fix potential NullPointerException for Null-Value Record fields

### DIFF
--- a/nifi-snowflake-processors/src/main/java/dev/anthu/processors/snowflake/PutSnowflakeStreamIngestAsVariant.java
+++ b/nifi-snowflake-processors/src/main/java/dev/anthu/processors/snowflake/PutSnowflakeStreamIngestAsVariant.java
@@ -143,8 +143,8 @@ public class PutSnowflakeStreamIngestAsVariant extends AbstractProcessor {
             while ((record = reader.nextRecord()) != null) {
                 ObjectNode variantObject = mapper.createObjectNode();
                 for (RecordField field : recordSchema.getFields()) {
-                    Object recordValue = record.getValue(field.getFieldName());
-                    variantObject.put(field.getFieldName(), recordValue.toString());
+                    String recordValue = record.getAsString(field.getFieldName());
+                    variantObject.put(field.getFieldName(), recordValue);
                     getLogger().debug("Adding {} as {}", field.getFieldName(), recordValue);
                 }
 


### PR DESCRIPTION
If a record field is not filled, there is a potential NullPointerException.
This PR fixes it by using the built-in method to retrieve Strings from the record if available.